### PR TITLE
feat: disable choosing date below the maximum age to apply for Hack Club

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,3 +48,10 @@ export function calculateMinDate() {
 
   return `${year}-${month}-${date}`
 }
+
+export function handleChangeInDate (date, stateSetter) {
+  const inputDate = new Date(date);
+  const minDate =  new Date(calculateMinDate())
+
+  stateSetter( minDate > inputDate)
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,5 @@
+import manifest from "../manifest"
+
 export function validateEmail(email) {
   const re =
     /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -25,4 +27,24 @@ export function returnLocalizedQuestionText(locale, item, key){
   else {
     return item.translations[locale][key]
   }
+}
+
+export function calculateMinDate() {
+  const currentDate = new Date()
+  const maximumAge = manifest.metaData.maximumAge
+  currentDate.setFullYear(currentDate.getFullYear() - maximumAge)
+
+  const year = `${currentDate.getFullYear()}`
+
+  const month =
+    currentDate.getMonth().toString().length == 1
+      ? `0${currentDate.getMonth()}`
+      : `${currentDate.getMonth()}`
+
+  const date =
+    currentDate.getDate().toString().length == 1
+      ? `0${currentDate.getDate()}`
+      : `${currentDate.getDate()}`
+
+  return `${year}-${month}-${date}`
 }

--- a/manifest.js
+++ b/manifest.js
@@ -226,12 +226,12 @@ export default {
         },
         {
           key: 'Birthday',
-          label: 'Birthday',
+          label: 'Birthday (maximum age is 17 years)',
           type: 'string',
           inputType: 'date',
           translations: {
             'pt-BR': {
-              label: 'Data de Aniversário'
+              label: 'Data de Aniversário (idade máxima é 17 anos)'
             }
           },
           optional: false

--- a/manifest.js
+++ b/manifest.js
@@ -226,14 +226,12 @@ export default {
         },
         {
           key: 'Birthday',
-          label:
-            "Birthday (FYI: we don't accept Hack Club applications from universities or from teachers)",
+          label: 'Birthday',
           type: 'string',
           inputType: 'date',
           translations: {
             'pt-BR': {
-              label:
-                'Data de Aniversário ( FYI: não aceitamos inscrições do Hack Club de universidades ou de professores)'
+              label: 'Data de Aniversário'
             }
           },
           optional: false

--- a/manifest.js
+++ b/manifest.js
@@ -28,8 +28,7 @@ export default {
             'pt-BR': {
               label:
                 'Há quanto tempo você e seus co-líderes se conhecem e como vocês se conheceram?',
-              sublabel:
-                '(Não tem problema se for liderar seu clube sozinho!)'
+              sublabel: '(Não tem problema se for liderar seu clube sozinho!)'
             }
           },
           type: 'paragraph',
@@ -53,7 +52,8 @@ export default {
           translations: {
             'pt-BR': {
               label: 'Onde você está planejando criar seu Hack Club?',
-              sublabel: '(Coloque o nome do local. Exemplo: "Escola Hacker Feliz")',
+              sublabel:
+                '(Coloque o nome do local. Exemplo: "Escola Hacker Feliz")',
               placeholder: 'Escola Hacker Feliz'
             }
           },
@@ -424,7 +424,8 @@ export default {
                     href="https://www.quora.com/When-have-you-most-successfully-hacked-a-non-computer-system-to-your-advantage"
                     style={{ color: '#338eda' }}
                   >
-                    {' '}Aqui estão alguns exemplos do que estamos buscando
+                    {' '}
+                    Aqui estão alguns exemplos do que estamos buscando
                   </a>
                   .
                 </>
@@ -445,7 +446,7 @@ export default {
             'pt-BR': {
               label:
                 'Conte-nos sobre algo que você fez que foi pessoalmente significativo para você.',
-                sublabel: '(coloque links, se possível)'
+              sublabel: '(coloque links, se possível)'
             }
           },
           optional: false,
@@ -459,8 +460,7 @@ export default {
           type: 'paragraph',
           translations: {
             'pt-BR': {
-              label:
-                'O que você aprendeu recentemente?',
+              label: 'O que você aprendeu recentemente?',
               sublabel:
                 'Não precisa ser relacionado ao Hack Club nem ter relação com programação. :)'
             }
@@ -488,5 +488,8 @@ export default {
         }
       ]
     }
-  ]
+  ],
+  metaData: {
+    maximumAge: 17 /**IN YEARS*/
+  }
 }

--- a/manifest.js
+++ b/manifest.js
@@ -490,6 +490,6 @@ export default {
     }
   ],
   metaData: {
-    maximumAge: 18 /**IN YEARS*/
+    maximumAge: 20 /**IN YEARS*/
   }
 }

--- a/manifest.js
+++ b/manifest.js
@@ -226,12 +226,14 @@ export default {
         },
         {
           key: 'Birthday',
-          label: 'Birthday (maximum age is 17 years)',
+          label:
+            "Birthday (FYI: we don't accept Hack Club applications from universities or from teachers)",
           type: 'string',
           inputType: 'date',
           translations: {
             'pt-BR': {
-              label: 'Data de Aniversário (idade máxima é 17 anos)'
+              label:
+                'Data de Aniversário ( FYI: não aceitamos inscrições do Hack Club de universidades ou de professores)'
             }
           },
           optional: false
@@ -490,6 +492,6 @@ export default {
     }
   ],
   metaData: {
-    maximumAge: 17 /**IN YEARS*/
+    maximumAge: 18 /**IN YEARS*/
   }
 }

--- a/pages/[application]/[leader]/[type].js
+++ b/pages/[application]/[leader]/[type].js
@@ -22,7 +22,8 @@ import nookies from 'nookies'
 import { useRouter } from 'next/router'
 import {
   returnLocalizedMessage,
-  returnLocalizedQuestionText
+  returnLocalizedQuestionText,
+  calculateMinDate
 } from '../../../lib/helpers'
 
 
@@ -239,6 +240,9 @@ export default function ApplicationClub({
                       type={item.inputType}
                       name="email"
                       value={data[item.key] !== undefined ? data[item.key] : ''}
+                      min={
+                        item.inputType === 'date' ? calculateMinDate() : null
+                      }
                       sx={{
                         border: '1px solid',
                         borderColor: 'rgb(221, 225, 228)',

--- a/pages/[application]/[leader]/[type].js
+++ b/pages/[application]/[leader]/[type].js
@@ -23,7 +23,7 @@ import { useRouter } from 'next/router'
 import {
   returnLocalizedMessage,
   returnLocalizedQuestionText,
-  calculateMinDate
+  handleChangeInDate
 } from '../../../lib/helpers'
 
 export default function ApplicationClub({
@@ -36,6 +36,8 @@ export default function ApplicationClub({
     params.type == 'club' ? applicationsRecord.fields : leaderRecord.fields
   )
   const [saved, setSavedState] = useState(true)
+  const [showFYI, setShowFYI] = useState(false)
+
   const savingStateRef = useRef(saved)
   const setSaved = data => {
     savingStateRef.current = data
@@ -225,6 +227,7 @@ export default function ApplicationClub({
                         newData[item.key] = e.target.value
                         setData({ ...data, ...newData })
                         setSaved(false)
+
                       }}
                       placeholder={returnLocalizedQuestionText(
                         router.locale,
@@ -241,12 +244,9 @@ export default function ApplicationClub({
                       type={item.inputType}
                       name="email"
                       value={data[item.key] !== undefined ? data[item.key] : ''}
-                      min={
-                        item.inputType === 'date' ? calculateMinDate() : null
+                      onInput={
+                        item.inputType === 'date' ? (e) => {handleChangeInDate(e.target.value, setShowFYI)} : null
                       }
-                      onInput={() => {
-                        item.inputType === 'date' ? calculateMinDate() : null
-                      }}
                       sx={{
                         border: '1px solid',
                         borderColor: 'rgb(221, 225, 228)',
@@ -301,8 +301,10 @@ export default function ApplicationClub({
                         }}
                         as="p"
                       >
-                        (FYI: we don't accept Hack Club applications from
-                        universities or from teachers)
+                        { showFYI? `(${returnLocalizedMessage(
+                          router.locale,
+                          'FYI_WE_DONT_ACCEPT_FROM_UNI_AND_TEACHERS'
+                        )})`: null}
                       </Text>
                     ) : null}
                     {item.words && (

--- a/pages/[application]/[leader]/[type].js
+++ b/pages/[application]/[leader]/[type].js
@@ -26,7 +26,6 @@ import {
   calculateMinDate
 } from '../../../lib/helpers'
 
-
 export default function ApplicationClub({
   notFound,
   applicationsRecord,
@@ -36,7 +35,7 @@ export default function ApplicationClub({
   const [data, setData] = useState(
     params.type == 'club' ? applicationsRecord.fields : leaderRecord.fields
   )
-  const [ saved, setSavedState ] = useState(true);
+  const [saved, setSavedState] = useState(true)
   const savingStateRef = useRef(saved)
   const setSaved = data => {
     savingStateRef.current = data
@@ -44,20 +43,24 @@ export default function ApplicationClub({
   }
 
   const poster = async () => {
-    const appOrLeader = params.type === 'club' ? params.application : params.leader;
+    const appOrLeader =
+      params.type === 'club' ? params.application : params.leader
 
     const msg = { body: JSON.stringify(data), method: 'POST' }
-    const fetched = await fetch(`/api/${params.type}/save?id=${appOrLeader}`, msg);
-    const json = await fetched.json();
+    const fetched = await fetch(
+      `/api/${params.type}/save?id=${appOrLeader}`,
+      msg
+    )
+    const json = await fetched.json()
 
     if (json.success) {
-      setSaved(true);
+      setSaved(true)
     } else {
-      console.error(json);
+      console.error(json)
       alert(`❌ ${returnLocalizedMessage(router.locale, 'ERROR')}`)
-    };
+    }
 
-    return json;
+    return json
   }
 
   const router = useRouter()
@@ -75,12 +78,10 @@ export default function ApplicationClub({
 
   async function goHome(autoSave = true) {
     if (!saved) {
-      if (autoSave ||
+      if (
+        autoSave ||
         window.confirm(
-          returnLocalizedMessage(
-            router.locale,
-            'ARE_YOU_SURE_YOU_WANT_TO_SAVE'
-          )
+          returnLocalizedMessage(router.locale, 'ARE_YOU_SURE_YOU_WANT_TO_SAVE')
         )
       ) {
         await poster()
@@ -243,6 +244,9 @@ export default function ApplicationClub({
                       min={
                         item.inputType === 'date' ? calculateMinDate() : null
                       }
+                      onInput={() => {
+                        item.inputType === 'date' ? calculateMinDate() : null
+                      }}
                       sx={{
                         border: '1px solid',
                         borderColor: 'rgb(221, 225, 228)',
@@ -288,6 +292,19 @@ export default function ApplicationClub({
                             }
                         : {})}
                     />
+                    {item.inputType === 'date' ? (
+                      <Text
+                        sx={{
+                          color: 'orange',
+                          fontWeight: 'bold',
+                          marginTop: [2]
+                        }}
+                        as="p"
+                      >
+                        (FYI: we don't accept Hack Club applications from
+                        universities or from teachers)
+                      </Text>
+                    ) : null}
                     {item.words && (
                       <Text
                         sx={{ fontSize: '18px', color: 'muted', mt: 1 }}

--- a/translations/en-US.js
+++ b/translations/en-US.js
@@ -44,7 +44,8 @@ export const messageObject =  {
   "WORDS": "words",
   "WORD": "word",
   "SO_FAR": "so far",
-  'ARE_YOU_SURE_YOU_WANT_TO_SAVE': "Would you like to save? Click Cancel to skip saving."
+  "ARE_YOU_SURE_YOU_WANT_TO_SAVE": "Would you like to save? Click Cancel to skip saving.",
+  "FYI_WE_DONT_ACCEPT_FROM_UNI_AND_TEACHERS":"(FYI: we don't accept Hack Club applications from universities or from teachers)"
 }
 
  

--- a/translations/en-US.js
+++ b/translations/en-US.js
@@ -45,7 +45,7 @@ export const messageObject =  {
   "WORD": "word",
   "SO_FAR": "so far",
   "ARE_YOU_SURE_YOU_WANT_TO_SAVE": "Would you like to save? Click Cancel to skip saving.",
-  "FYI_WE_DONT_ACCEPT_FROM_UNI_AND_TEACHERS":"(FYI: we don't accept Hack Club applications from universities or from teachers)"
+  "FYI_WE_DONT_ACCEPT_FROM_UNI_AND_TEACHERS":"FYI: we don't accept Hack Club applications from universities or from teachers"
 }
 
  

--- a/translations/pt-BR.js
+++ b/translations/pt-BR.js
@@ -43,5 +43,6 @@ export const messageObject = {
   "WORDS": "palavras",
   "WORD": "palavra",
   "SO_FAR": "até aqui",
-  'ARE_YOU_SURE_YOU_WANT_TO_SAVE': "Você gostaria de salvar? Clique em Cancelar para pular o salvamento."
+  "ARE_YOU_SURE_YOU_WANT_TO_SAVE": "Você gostaria de salvar? Clique em Cancelar para pular o salvamento.",
+  "FYI_WE_DONT_ACCEPT_FROM_UNI_AND_TEACHERS": "FYI: não aceitamos inscrições do Hack Club de universidades ou de professores"
 }


### PR DESCRIPTION
We have been getting applications, where the person applying for Hack Club is not from the ideal age group that hack club aims to empower.

Disabling choosing a date of birth below the maximum age to apply for Hack Club can solve this, the PR enables this feature.

the `manifest.json` file has a new field, `metaData`, which has the `maximumAge` { in years } field.

The PR introduces a new helper function `calculateMinAge`, which reads the `maximumAge` field from `manifest.json` and returns a minimum date of birth to apply for a Hack Club in the format `year-month-date`.

Later on, this function is used to fill the value of the `min` attribute of the HTML Date picker so that any date below this minimum date of birth can be disabled.

cc: @leomcelroy 