### PR TITLE
Add Assemble Video to Status Page

### DIFF
--- a/pages/[application]/[leader]/status.js
+++ b/pages/[application]/[leader]/status.js
@@ -180,17 +180,16 @@ export default function ApplicationOnboarding({
                   </li>
                 </ol>
               </Text>
-              <Box
-                sx={{
-                  marginTop: ['0.5rem', '1rem']
-                }}
-              >
-                <a href="https://assemble.hackclub.com" target="_blank">
-                  <img
-                    src="https://cloud-aibuyxog8-hack-club-bot.vercel.app/0image.png"
-                    width="80%"
-                  />
-                </a>
+              <Box sx={{ my: '1rem' }}>
+                <iframe
+                  width="80%"
+                  height="315"
+                  src="https://www.youtube.com/embed/PnK4gzO6S3Q"
+                  title="YouTube video player"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen
+                ></iframe>
               </Box>
             </Box>
 


### PR DESCRIPTION
Replaces the photo with the latest Assemble video on the status page (re: Holly's Request!) If you could add the `hacktoberfest-accepted` tag, that would be greatly appreciated!

<img width="500" alt="image" src="https://user-images.githubusercontent.com/64426829/194711719-6995c634-fc43-45ae-bccd-fbc3aca6f293.png">
