### PR TITLE
proudly open source badge should send the user to this repo (instead of signing the user out)

### DIFF
--- a/pages/[application]/[leader]/index.js
+++ b/pages/[application]/[leader]/index.js
@@ -34,13 +34,14 @@ export default function ApplicationHome({
   async function sendInvite() {
     if (validateEmail(emailToInvite)) {
       const loginAPICall = await fetch(
-        `/api/invite?email=${encodeURIComponent(emailToInvite)}&id=${params.application
+        `/api/invite?email=${encodeURIComponent(emailToInvite)}&id=${
+          params.application
         }&locale=${router.locale}`
       ).then(r => r.json())
       if (loginAPICall.success) {
         setInviteMessage([
           applicationsRecord.fields['Prospective Leaders'][
-          applicationsRecord.fields['Prospective Leaders'].length + 1
+            applicationsRecord.fields['Prospective Leaders'].length + 1
           ],
           `✅ ${returnLocalizedMessage(router.locale, 'INVITED')}`
         ])
@@ -51,7 +52,7 @@ export default function ApplicationHome({
         console.error(loginAPICall)
         setInviteMessage([
           applicationsRecord.fields['Prospective Leaders'][
-          applicationsRecord.fields['Prospective Leaders'].length + 1
+            applicationsRecord.fields['Prospective Leaders'].length + 1
           ],
           `✅ ${returnLocalizedMessage(router.locale, 'INVITED')}`
         ])
@@ -203,7 +204,7 @@ export default function ApplicationHome({
                     onClick={() =>
                       deleteLeader(
                         applicationsRecord.fields['Prospective Leaders'][
-                        leaderIndex
+                          leaderIndex
                         ]
                       )
                     }
@@ -230,18 +231,19 @@ export default function ApplicationHome({
                   ],
                   transform: 'translateY(-0.2px)',
                   mr: '5px',
-                  mb: `${warning &&
+                  mb: `${
+                    warning &&
                     applicationsRecord.fields['Prospective Leaders'][
-                    leaderIndex
+                      leaderIndex
                     ] === inviteMessage[0]
-                    ? '-8px'
-                    : '0px'
-                    }`
+                      ? '-8px'
+                      : '0px'
+                  }`
                 }}
                 onClick={() => (
                   setInviteMessage([
                     applicationsRecord.fields['Prospective Leaders'][
-                    leaderIndex
+                      leaderIndex
                     ],
                     returnLocalizedMessage(router.locale, 'ARE_YOU_SURE')
                   ]),
@@ -251,9 +253,9 @@ export default function ApplicationHome({
                 <Icon
                   glyph={
                     warning &&
-                      applicationsRecord.fields['Prospective Leaders'][
+                    applicationsRecord.fields['Prospective Leaders'][
                       leaderIndex
-                      ] === inviteMessage[0]
+                    ] === inviteMessage[0]
                       ? 'menu'
                       : 'member-remove'
                   }
@@ -275,7 +277,7 @@ export default function ApplicationHome({
                 onClick={() =>
                   deleteLeader(
                     applicationsRecord.fields['Prospective Leaders'][
-                    leaderIndex
+                      leaderIndex
                     ]
                   )
                 }
@@ -556,10 +558,7 @@ const OpenSourceCard = ({ router }) => {
         borderRadius: '15px'
       }}
       onClick={async () => {
-        await destroyCookie(null, 'authToken', {
-          path: '/'
-        })
-        router.push('/', '/', { scroll: false })
+        window.open('https://github.com/hackclub/apply', '_blank')
       }}
     >
       <Text

--- a/pages/[application]/[leader]/review.js
+++ b/pages/[application]/[leader]/review.js
@@ -39,13 +39,14 @@ export default function ApplicationReview({
   async function sendInvite() {
     if (validateEmail(emailToInvite)) {
       const loginAPICall = await fetch(
-        `/api/invite?email=${encodeURIComponent(emailToInvite)}&id=${params.application
+        `/api/invite?email=${encodeURIComponent(emailToInvite)}&id=${
+          params.application
         }&locale=${router.locale}`
       ).then(r => r.json())
       if (loginAPICall.success) {
         setInviteMessage([
           applicationsRecord.fields['Prospective Leaders'][
-          applicationsRecord.fields['Prospective Leaders'].length + 1
+            applicationsRecord.fields['Prospective Leaders'].length + 1
           ],
           `✅ ${returnLocalizedMessage(router.locale, 'INVITED')}`
         ])
@@ -56,7 +57,7 @@ export default function ApplicationReview({
         console.error(loginAPICall)
         setInviteMessage([
           applicationsRecord.fields['Prospective Leaders'][
-          applicationsRecord.fields['Prospective Leaders'].length + 1
+            applicationsRecord.fields['Prospective Leaders'].length + 1
           ],
           `✅ ${returnLocalizedMessage(router.locale, 'INVITED')}`
         ])
@@ -204,7 +205,7 @@ export default function ApplicationReview({
                     onClick={() =>
                       deleteLeader(
                         applicationsRecord.fields['Prospective Leaders'][
-                        leaderIndex
+                          leaderIndex
                         ]
                       )
                     }
@@ -231,18 +232,19 @@ export default function ApplicationReview({
                   ],
                   transform: 'translateY(-0.2px)',
                   mr: '5px',
-                  mb: `${warning &&
+                  mb: `${
+                    warning &&
                     applicationsRecord.fields['Prospective Leaders'][
-                    leaderIndex
+                      leaderIndex
                     ] === inviteMessage[0]
-                    ? '-8px'
-                    : '0px'
-                    }`
+                      ? '-8px'
+                      : '0px'
+                  }`
                 }}
                 onClick={() => (
                   setInviteMessage([
                     applicationsRecord.fields['Prospective Leaders'][
-                    leaderIndex
+                      leaderIndex
                     ],
                     returnLocalizedMessage(router.locale, 'ARE_YOU_SURE')
                   ]),
@@ -252,9 +254,9 @@ export default function ApplicationReview({
                 <Icon
                   glyph={
                     warning &&
-                      applicationsRecord.fields['Prospective Leaders'][
+                    applicationsRecord.fields['Prospective Leaders'][
                       leaderIndex
-                      ] === inviteMessage[0]
+                    ] === inviteMessage[0]
                       ? 'menu'
                       : 'member-remove'
                   }
@@ -276,7 +278,7 @@ export default function ApplicationReview({
                 onClick={() =>
                   deleteLeader(
                     applicationsRecord.fields['Prospective Leaders'][
-                    leaderIndex
+                      leaderIndex
                     ]
                   )
                 }
@@ -313,10 +315,11 @@ export default function ApplicationReview({
               height: '40px',
               minWidth: '150px',
               fontWeight: 'bold',
-              cursor: `${applicationsRecord.fields['Submitted']
-                ? 'not-allowed'
-                : 'pointer'
-                }`
+              cursor: `${
+                applicationsRecord.fields['Submitted']
+                  ? 'not-allowed'
+                  : 'pointer'
+              }`
             }}
             onClick={() => sendInvite()}
           >
@@ -480,23 +483,23 @@ export default function ApplicationReview({
             width: '100%',
             textTransform: 'uppercase',
             ...(applicationsRecord.fields['All Complete (incl Leaders)'] != 1 ||
-              acceptCOC === false ||
-              applicationsRecord.fields['Submitted']
+            acceptCOC === false ||
+            applicationsRecord.fields['Submitted']
               ? {
-                opacity: 0.3,
-                ':hover,:focus': {
-                  transform: 'none',
-                  boxShadow: 'none',
-                  cursor: 'not-allowed'
+                  opacity: 0.3,
+                  ':hover,:focus': {
+                    transform: 'none',
+                    boxShadow: 'none',
+                    cursor: 'not-allowed'
+                  }
                 }
-              }
               : {})
           }}
           variant="ctaLg"
           onClick={() =>
             applicationsRecord.fields['All Complete (incl Leaders)'] != 1 ||
-              acceptCOC === false ||
-              applicationsRecord.fields['Submitted']
+            acceptCOC === false ||
+            applicationsRecord.fields['Submitted']
               ? console.log(applicationsRecord)
               : submitApplication(applicationsRecord.fields)
           }
@@ -504,15 +507,12 @@ export default function ApplicationReview({
           {submitButton}
         </Button>
         <Text sx={{ mt: 8 }}>
-          {
-            acceptCOC === false ?
-              "You must agree to the Hacker Code of Conduct to Submit Your Application" :
-              applicationsRecord.fields['All Complete (incl Leaders)'] !== 1 ?
-                "Your Hack Club application is not complete. Please ensure you have completed your personal profile, your club profile, and that all of your co-leaders have submitted their application if they were added to the club application." :
-                ""
-          }
+          {acceptCOC === false
+            ? 'You must agree to the Hacker Code of Conduct to Submit Your Application'
+            : applicationsRecord.fields['All Complete (incl Leaders)'] !== 1
+            ? 'Your Hack Club application is not complete. Please ensure you have completed your personal profile, your club profile, and that all of your co-leaders have submitted their application if they were added to the club application.'
+            : ''}
         </Text>
-
       </Card>
       <Box
         sx={{
@@ -575,7 +575,7 @@ const ContactCard = ({ router }) => (
       color: 'blue',
       display: 'flex',
       alignItems: 'center',
-        '> svg': { display: 'inline' }
+      '> svg': { display: 'inline' }
     }}
   >
     <Icon glyph="message" />
@@ -620,10 +620,7 @@ const OpenSourceCard = ({ router }) => {
         borderRadius: '15px'
       }}
       onClick={async () => {
-        await destroyCookie(null, 'authToken', {
-          path: '/'
-        })
-        router.push('/', '/', { scroll: false })
+        window.open('https://github.com/hackclub/apply', '_blank')
       }}
     >
       <Text

--- a/pages/[application]/[leader]/status.js
+++ b/pages/[application]/[leader]/status.js
@@ -29,33 +29,33 @@ export default function ApplicationOnboarding({
     {
       applicationStatus === 'applied'
         ? (setApplicationMessage(
-          `${returnLocalizedMessage(router.locale, 'IS_BEING_REVIEWED')}`
-        ),
+            `${returnLocalizedMessage(router.locale, 'IS_BEING_REVIEWED')}`
+          ),
           setMessageColor('#000000'))
         : applicationStatus === 'rejected'
-          ? (setApplicationMessage(
+        ? (setApplicationMessage(
             `${returnLocalizedMessage(router.locale, 'REJECTED')}`
           ),
-            setMessageColor('#ec3750'))
-          : applicationStatus === 'awaiting onboarding'
-            ? (setApplicationMessage(
-              `${returnLocalizedMessage(router.locale, 'ACCEPTED')}`
-            ),
-              setMessageColor('#33d6a6'))
-            : applicationStatus === 'onboarded'
-              ? (setApplicationMessage(
-                `${returnLocalizedMessage(router.locale, 'ACCEPTED')}`
-              ),
-                setMessageColor('#33d6a6'))
-              : applicationStatus === 'inactive'
-                ? (setApplicationMessage(
-                  `${returnLocalizedMessage(router.locale, 'INACTIVE')}`
-                ),
-                  setMessageColor('#ff8c37'))
-                : (setApplicationMessage(
-                  `${returnLocalizedMessage(router.locale, 'PROCESSING')}`
-                ),
-                  setMessageColor('#000000'))
+          setMessageColor('#ec3750'))
+        : applicationStatus === 'awaiting onboarding'
+        ? (setApplicationMessage(
+            `${returnLocalizedMessage(router.locale, 'ACCEPTED')}`
+          ),
+          setMessageColor('#33d6a6'))
+        : applicationStatus === 'onboarded'
+        ? (setApplicationMessage(
+            `${returnLocalizedMessage(router.locale, 'ACCEPTED')}`
+          ),
+          setMessageColor('#33d6a6'))
+        : applicationStatus === 'inactive'
+        ? (setApplicationMessage(
+            `${returnLocalizedMessage(router.locale, 'INACTIVE')}`
+          ),
+          setMessageColor('#ff8c37'))
+        : (setApplicationMessage(
+            `${returnLocalizedMessage(router.locale, 'PROCESSING')}`
+          ),
+          setMessageColor('#000000'))
     }
   }, [])
 
@@ -92,8 +92,8 @@ export default function ApplicationOnboarding({
       }}
     >
       {applicationStatus != 'rejected' &&
-        applicationStatus !== 'inactive' &&
-        applicationStatus != null ? (
+      applicationStatus !== 'inactive' &&
+      applicationStatus != null ? (
         <ConfettiOnSuccess applicationStatus={applicationStatus} />
       ) : null}
 
@@ -150,15 +150,16 @@ export default function ApplicationOnboarding({
                     }}
                     as="b"
                   >
-                    {returnLocalizedMessage(router.locale, 'THREE_KEY_RESOURCES')}
+                    {returnLocalizedMessage(
+                      router.locale,
+                      'THREE_KEY_RESOURCES'
+                    )}
                   </Text>
                 </b>
                 <ol>
                   <li>{returnLocalizedMessage(router.locale, 'YSWS')}</li>
                   <li>{returnLocalizedMessage(router.locale, 'PIZZA')}</li>
-                  <li>
-                    {returnLocalizedMessage(router.locale, 'HCB')}
-                  </li>
+                  <li>{returnLocalizedMessage(router.locale, 'HCB')}</li>
                 </ol>
               </Text>
               <Box sx={{ my: '1rem' }}>
@@ -245,8 +246,20 @@ export default function ApplicationOnboarding({
                   </a>{' '}
                   {returnLocalizedMessage(router.locale, 'BOREAL_DETAILS_1')}
                 </Box>
-                <Box sx={{ marginTop: '0.5em' }}> {returnLocalizedMessage(router.locale, 'BOREAL_DETAILS_2')} </Box>
-                <Box sx={{ marginTop: '0.5em' }}> {returnLocalizedMessage(router.locale, 'BOREAL_DETAILS_3')} </Box>
+                <Box sx={{ marginTop: '0.5em' }}>
+                  {' '}
+                  {returnLocalizedMessage(
+                    router.locale,
+                    'BOREAL_DETAILS_2'
+                  )}{' '}
+                </Box>
+                <Box sx={{ marginTop: '0.5em' }}>
+                  {' '}
+                  {returnLocalizedMessage(
+                    router.locale,
+                    'BOREAL_DETAILS_3'
+                  )}{' '}
+                </Box>
               </Text>
               <Box sx={{ my: '1rem' }}>
                 <iframe
@@ -341,8 +354,8 @@ export default function ApplicationOnboarding({
                   {trackerRecord[0].fields['Ambassador'] === 'HQ'
                     ? 'Holly from HQ.'
                     : trackerRecord[0].fields['Ambassador'] === 'APAC'
-                      ? 'Anna and Harsh from Hack Club APAC.'
-                      : 'Hack Club HQ.'}
+                    ? 'Anna and Harsh from Hack Club APAC.'
+                    : 'Hack Club HQ.'}
                 </b>{' '}
                 {returnLocalizedMessage(
                   router.locale,
@@ -535,10 +548,7 @@ const OpenSourceCard = ({ router }) => {
         borderRadius: '15px'
       }}
       onClick={async () => {
-        await destroyCookie(null, 'authToken', {
-          path: '/'
-        })
-        router.push('/', '/', { scroll: false })
+        window.open('https://github.com/hackclub/apply', '_blank')
       }}
     >
       <Text


### PR DESCRIPTION
on click, the "Proudly Open Source" badge removes the `authToken` cookie and sends the user to the `/` route, effectively logging the user out. this problem is mentioned in #87.

the changes made make it so that users are sent to [this repo](https://github.com/hackclub/apply) instead.